### PR TITLE
Refactor auth finding methods to be more intuitive & consistent

### DIFF
--- a/lib/oauth2/lib/secure_code_scheme.rb
+++ b/lib/oauth2/lib/secure_code_scheme.rb
@@ -70,8 +70,8 @@ module OAuth2
       def self.aes_cipher(direction)
         cipher = OpenSSL::Cipher::AES.new(256, :CBC)
         cipher.send(direction)
-        cipher.key  = ENV[CIPHER_KEY] || cipher.random_key
-        cipher.iv   = ENV[CIPHER_IV]  || cipher.random_iv
+        cipher.key  = ENV[CIPHER_KEY] || raise("Missing '#{CIPHER_KEY}' environment variable.")
+        cipher.iv   = ENV[CIPHER_IV]  || raise("Missing '#{CIPHER_IV}' environment variable.")
         cipher
       end
 

--- a/lib/oauth2/model.rb
+++ b/lib/oauth2/model.rb
@@ -14,21 +14,5 @@ module OAuth2
     def self.duplicate_record_error?(error)
       error.class.name == 'ActiveRecord::RecordNotUnique'
     end
-
-    # This will only return an authorisation for JWT and non-JWT tokens
-    # TODO: Refactor this to an access token service (probably exchange)
-    def self.find_access_token(token_tuple)
-      return nil if token_tuple.nil?
-      return nil if Provider.token_decoder.nil? || !Provider.token_decoder[0].respond_to?(Provider.token_decoder[1])
-      if token_tuple[0] == :jwt
-        begin
-          Authorization.find_by_jwt(Provider.token_decoder[0].send(Provider.token_decoder[1], token_tuple[1]))
-        rescue JSON::JWT::Exception => e
-          nil
-        end
-      else
-        Authorization.find_by_access_token_hash(Lib::SecureCodeScheme.hashify(token_tuple[1]))
-      end
-    end
   end
 end

--- a/lib/oauth2/provider/access_token.rb
+++ b/lib/oauth2/provider/access_token.rb
@@ -46,7 +46,7 @@
       private
 
         def authorize!(access_token, error)
-          return unless @authorization = Model.find_access_token([:access_token, access_token])
+          return unless @authorization = Model::Authorization.find_by_token_tuple([:access_token, access_token])
           @authorization.update_attribute(:access_token, nil) if error
         end
 


### PR DESCRIPTION
Move token finding method to its natural place on the Authorization model and rename. This method now always returns an authorization. Previously this method could return a user which was inconsistent/confusing.

Raise error if cipher keys are not present instead of using random defaults. Random keys don't work as they need to be consistent across requests for the code challenge dance to work.